### PR TITLE
Don't initiate requests without running Aff

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "purescript-prelude": "^3.1.0",
     "purescript-node-http": "^4.0.0",
     "purescript-http-methods": "^3.0.0",
-    "purescript-aff-promise": "^0.6.0"
+    "purescript-aff-promise": "^0.7.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "pulp test"
   },
   "author": "",
   "license": "MIT",

--- a/src/Milkis.js
+++ b/src/Milkis.js
@@ -2,14 +2,20 @@ var fetch = require("node-fetch");
 
 exports.fetchImpl = function (url) {
   return function (options) {
-    return fetch(url, options);
+    return function () {
+      return fetch(url, options);
+    };
   };
 }
 
 exports.jsonImpl = function (response) {
-  return response.json();
+  return function() {
+    return response.json();
+  };
 }
 
 exports.textImpl = function (response) {
-  return response.text();
+  return function() {
+    return response.text();
+  };
 }

--- a/src/Milkis.purs
+++ b/src/Milkis.purs
@@ -12,9 +12,7 @@ import Prelude
 
 import Control.Monad.Aff (Aff)
 import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Class (liftEff)
-import Control.Monad.Eff.Exception (EXCEPTION)
-import Control.Promise (Promise, toAff)
+import Control.Promise (Promise, toAffE)
 import Data.Foreign (Foreign)
 import Data.HTTP.Method (Method(..))
 import Data.Maybe (Maybe(..), fromMaybe)
@@ -37,16 +35,15 @@ fetch :: forall eff
   .  String
   -> FetchOptions
   -> Aff (http :: HTTP | eff) Response
-fetch url opts =
-  (liftEff $ fetchImpl url (fetchOptionsToRawFetchOptions opts)) >>= toAff
+fetch url opts = toAffE $ fetchImpl url (fetchOptionsToRawFetchOptions opts)
 
 json :: forall eff
   .  Response
-  -> Aff (http :: HTTP | eff) Foreign
-json res = liftEff (jsonImpl res) >>= toAff
+  -> Aff eff Foreign
+json res = toAffE (jsonImpl res) 
 
-text :: forall eff. Response -> Aff (http :: HTTP | eff) String
-text res = liftEff (textImpl res) >>= toAff
+text :: forall eff. Response -> Aff eff String
+text res = toAffE (textImpl res)
 
 fetchOptionsToRawFetchOptions :: FetchOptions -> RawFetchOptions
 fetchOptionsToRawFetchOptions opts =
@@ -70,8 +67,8 @@ foreign import fetchImpl :: forall eff.
 
 foreign import jsonImpl :: forall eff.
   Response
-  -> Eff (http:: HTTP | eff) (Promise Foreign)
+  -> Eff eff (Promise Foreign)
 
 foreign import textImpl :: forall eff.
   Response
-  -> Eff (http:: HTTP | eff) (Promise String)
+  -> Eff eff (Promise String)


### PR DESCRIPTION
I've added the `HTTP` effect to `json` and `text` because they have to have some effect - I think running `text` is effectful because (ignoring kicking off computation) it changes stream state? ICBW. There may be a better effect to use but this seemed simpler to me.