### PR TITLE
Updates for Aff v4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,13 +10,13 @@
   ],
   "dependencies": {
     "purescript-prelude": "^3.1.0",
-    "purescript-node-http": "^4.0.0",
+    "purescript-node-http": "^4.1.0",
     "purescript-http-methods": "^3.0.0",
-    "purescript-aff-promise": "^0.7.0"
+    "purescript-aff-promise": "^1.0.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-spec": "^1.0.0"
+    "purescript-spec": "^2.0.0"
   },
   "authors": [
     "justinwoo <moomoowoo@gmail.com>",


### PR DESCRIPTION
Bumps a bunch of deps, and uses your `purescript-aff-promise` commit with Aff v4 support. This should probably stay open until `-aff-promise` gets a proper version bump to work with Aff v4.