### PR TITLE
added arrayBuffer function

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,8 @@
     "purescript-prelude": "^4.0.0",
     "purescript-aff-promise": "^2.0.0",
     "purescript-typelevel-prelude": "^3.0.0",
-    "purescript-foreign-object": "^1.0.0"
+    "purescript-foreign-object": "^1.0.0",
+    "purescript-arraybuffer-types": "^2.0.0"
   },
   "devDependencies": {
     "purescript-spec": "justinwoo/purescript-spec#compiler/0.12"

--- a/src/Milkis.js
+++ b/src/Milkis.js
@@ -25,6 +25,12 @@ exports.textImpl = function(response) {
   };
 };
 
+exports.arrayBufferImpl = function(response) {
+  return function() {
+    return response.arrayBuffer();
+  };
+};
+
 exports.fromRecordImpl = function(r) {
   return r;
 };

--- a/src/Milkis.purs
+++ b/src/Milkis.purs
@@ -18,6 +18,7 @@ module Milkis
   , fetch
   , json
   , text
+  , arrayBuffer
   , makeHeaders
   , statusCode
   ) where
@@ -25,6 +26,7 @@ module Milkis
 import Type.Row.Homogeneous
 
 import Control.Promise (Promise, toAffE)
+import Data.ArrayBuffer.Types (ArrayBuffer)
 import Data.Newtype (class Newtype)
 import Effect (Effect)
 import Effect.Aff (Aff)
@@ -110,6 +112,9 @@ json res = toAffE (jsonImpl res)
 text :: Response -> Aff String
 text res = toAffE (textImpl res)
 
+arrayBuffer :: Response -> Aff ArrayBuffer 
+arrayBuffer res = toAffE (arrayBufferImpl res)
+
 statusCode :: Response -> Int
 statusCode response = response'.status
   where
@@ -128,3 +133,5 @@ foreign import _fetch
 foreign import jsonImpl :: Response -> Effect (Promise Foreign)
 
 foreign import textImpl :: Response -> Effect (Promise String)
+
+foreign import arrayBufferImpl :: Response -> Effect (Promise ArrayBuffer)

--- a/test/Main.js
+++ b/test/Main.js
@@ -1,0 +1,3 @@
+exports.byteLength = function(arrayBuffer) {
+  return arrayBuffer.byteLength;
+};

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,6 +2,7 @@ module Test.Main where
 
 import Prelude
 
+import Data.ArrayBuffer.Types (ArrayBuffer)
 import Data.Either (Either(..), isRight)
 import Data.String (null)
 import Effect (Effect)
@@ -29,6 +30,18 @@ main = run [consoleReporter] do
           let code = M.statusCode response
           code `shouldEqual` 200
           null stuff `shouldEqual` false
+
+    it "get works and gets a body" do
+      _response <- attempt $ fetch (M.URL "https://www.google.com") M.defaultFetchOptions
+      case _response of
+        Left e -> do
+          fail $ "failed with " <> show e
+        Right response -> do
+          arrayBuffer <- M.arrayBuffer response
+          let code = M.statusCode response
+          code `shouldEqual` 200
+          (byteLength arrayBuffer > 0) `shouldEqual` true 
+
     it "post works" do
       let
         opts =
@@ -46,3 +59,6 @@ main = run [consoleReporter] do
       let opts = { method: M.deleteMethod }
       result <- attempt $ fetch (M.URL "https://www.google.com") opts
       isRight result `shouldEqual` true
+
+
+foreign import byteLength :: ArrayBuffer -> Int


### PR DESCRIPTION
I needed to get responses as an `ArrayBuffer` for some binary data, so I've added the method. I added `purescript-arraybuffer-types` as a dependency, but didn't want to add the entire `purescript-arraybuffer` lib, so in `test/Main.js` I've got a FFI to get the byteLength of `ArrayBuffers` for the test I wrote. Let me know if you'd like anything changed. 