### PR TITLE
Fix missing node-fetch when building using webpack

### DIFF
--- a/src/Milkis.Impl.Node.js
+++ b/src/Milkis.Impl.Node.js
@@ -1,1 +1,1 @@
-exports.nodeFetch = require("node-fetch");
+exports.nodeFetch = require("node-fetch").default;


### PR DESCRIPTION
When building using webpack, node-fetch can't be properly resolved. The workaround is to import the `default` property.

* See https://github.com/bitinn/node-fetch/issues/450#issuecomment-387045223