### PR TITLE
Add headers :: Response -> Object String

### DIFF
--- a/src/Milkis.js
+++ b/src/Milkis.js
@@ -25,6 +25,14 @@ exports.textImpl = function(response) {
   };
 };
 
+exports.headersImpl = function(response) {
+    let d = {};
+    for (h of response.headers) {
+        d[h[0]] = h[1];
+    };
+    return d;
+};
+
 exports.arrayBufferImpl = function(response) {
   return function() {
     return response.arrayBuffer();

--- a/src/Milkis.purs
+++ b/src/Milkis.purs
@@ -18,6 +18,7 @@ module Milkis
   , fetch
   , json
   , text
+  , headers
   , arrayBuffer
   , makeHeaders
   , statusCode
@@ -32,6 +33,7 @@ import Effect (Effect)
 import Effect.Aff (Aff)
 import Foreign (Foreign)
 import Foreign.Object as Object
+import Foreign.Object (Object)
 import Milkis.Impl (FetchImpl)
 import Prelude (class Show, ($))
 import Type.Row (class Union)
@@ -112,6 +114,9 @@ json res = toAffE (jsonImpl res)
 text :: Response -> Aff String
 text res = toAffE (textImpl res)
 
+headers :: Response -> Object String
+headers = headersImpl
+
 arrayBuffer :: Response -> Aff ArrayBuffer 
 arrayBuffer res = toAffE (arrayBufferImpl res)
 
@@ -133,5 +138,7 @@ foreign import _fetch
 foreign import jsonImpl :: Response -> Effect (Promise Foreign)
 
 foreign import textImpl :: Response -> Effect (Promise String)
+
+foreign import headersImpl :: Response -> Object String
 
 foreign import arrayBufferImpl :: Response -> Effect (Promise ArrayBuffer)

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -7,10 +7,11 @@ import Data.Either (Either(..), isRight)
 import Data.String (null)
 import Effect (Effect)
 import Effect.Aff (attempt, launchAff_)
+import Foreign.Object as Object
 import Milkis as M
 import Milkis.Impl.Node (nodeFetch)
 import Test.Spec (describe, it)
-import Test.Spec.Assertions (fail, shouldEqual)
+import Test.Spec.Assertions (fail, shouldEqual, shouldContain)
 import Test.Spec.Reporter.Console (consoleReporter)
 import Test.Spec.Runner (runSpec)
 
@@ -30,6 +31,9 @@ main = launchAff_ $ runSpec [consoleReporter] do
           let code = M.statusCode response
           code `shouldEqual` 200
           null stuff `shouldEqual` false
+          let headers = M.headers response
+          Object.keys headers `shouldContain` "content-type"
+          Object.keys headers `shouldContain` "content-encoding"
 
     it "get works and gets a body" do
       _response <- attempt $ fetch (M.URL "https://www.google.com") M.defaultFetchOptions
@@ -40,7 +44,7 @@ main = launchAff_ $ runSpec [consoleReporter] do
           arrayBuffer <- M.arrayBuffer response
           let code = M.statusCode response
           code `shouldEqual` 200
-          (byteLength arrayBuffer > 0) `shouldEqual` true 
+          (byteLength arrayBuffer > 0) `shouldEqual` true
 
     it "post works" do
       let


### PR DESCRIPTION
Accumulates the headers of a response and returns them as `Object`.

Upstream has a weird OO API for that, with getters and setters and
stuff, but in the spirit of KISS we just iterate it into an object.