### PR TITLE
we cannot use for..of in FFI

### DIFF
--- a/src/Milkis.js
+++ b/src/Milkis.js
@@ -25,12 +25,35 @@ exports.textImpl = function(response) {
   };
 };
 
-exports.headersImpl = function(response) {
-    let d = {};
-    for (h of response.headers) {
-        d[h[0]] = h[1];
-    };
-    return d;
+exports.headersImpl = function (response) {
+  var d = {};
+  var _iteratorNormalCompletion = true;
+  var _didIteratorError = false;
+  var _iteratorError = undefined;
+
+  // for of cannot be used in ES5
+  try {
+    for (var _iterator = response.headers[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+      h = _step.value;
+      d[h[0]] = h[1];
+    }
+  } catch (err) {
+    _didIteratorError = true;
+    _iteratorError = err;
+  } finally {
+    try {
+      if (!_iteratorNormalCompletion && _iterator.return != null) {
+        _iterator.return();
+      }
+    } finally {
+      if (_didIteratorError) {
+        throw _iteratorError;
+      }
+    }
+  }
+
+  ;
+  return d;
 };
 
 exports.arrayBufferImpl = function(response) {


### PR DESCRIPTION
cc @Profpatsch this was causing my builds to fail in some projects. This could be rewritten to real ES5 later, but ti's easier to just use this instead.

May be not required in future PureScript versions.