### PR TITLE
Add PATCH method

### DIFF
--- a/src/Milkis.purs
+++ b/src/Milkis.purs
@@ -94,6 +94,9 @@ postMethod = unsafeCoerce "POST"
 putMethod :: Method
 putMethod = unsafeCoerce "PUT"
 
+patchMethod :: Method
+patchMethod = unsafeCoerce "PATCH"
+
 deleteMethod :: Method
 deleteMethod = unsafeCoerce "DELETE"
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -68,6 +68,10 @@ main = launchAff_ $ runSpec [consoleReporter] do
       let opts = { method: M.putMethod }
       result <- attempt $ fetch (M.URL "https://www.google.com") opts
       isRight result `shouldEqual` true
+    it "patch works" do
+      let opts = { method: M.patchMethod }
+      result <- attempt $ fetch (M.URL "https://www.google.com") opts
+      isRight result `shouldEqual` true
     it "delete works" do
       let opts = { method: M.deleteMethod }
       result <- attempt $ fetch (M.URL "https://www.google.com") opts


### PR DESCRIPTION
This PR is adding the [`PATCH` method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PATCH) to the library. The change is very similar to `PUT`.